### PR TITLE
Fixed homographic function for certain inputs.

### DIFF
--- a/src/contfrac/continued_fractions.py
+++ b/src/contfrac/continued_fractions.py
@@ -74,7 +74,7 @@ def _homographic_transform(x : Generator[int, None, None], a : int, b : int, c :
 
     while True:
 
-        if c != 0 and d != 0 and c*d > 0 and math.trunc(a/c) == math.trunc(b/d) != 0:
+        if c*d > 0 and math.trunc(a/c) == math.trunc(b/d):
             # emit next coefficient and EGEST
 
             q = math.trunc(a/c)


### PR DESCRIPTION
I used an input fraction with coefficients 2 1 1 2 1 1 1 2 1 1 1 1 1 2... (each group of ones is the length of the next prime. Then getting the coefficients of homographic(2, 3, 3, 4) ran in an infinite loop until I made this change.

Additionally, we don't need to test that c and d are nonzero because c*d > 0 already does this.