### PR TITLE
Allowing taking a limited number of coefficients without list

### DIFF
--- a/src/contfrac/continued_fractions.py
+++ b/src/contfrac/continued_fractions.py
@@ -237,7 +237,7 @@ class ContFrac():
         return f"{self.__class__.__name__}({self.as_rational() if not self.is_inf() else '∞'})"
 
 
-    def coefficients(self) -> Generator[int, None, None]:
+    def coefficients(self, N : int | None = None) -> Generator[int, None, None]:
         """The coefficients stream of the continued fraction
 
         `            1
@@ -254,14 +254,17 @@ class ContFrac():
         `[a0, a1, a2, ...]`
 
         """
-        return self._coefficients()
+        if N == None:
+            return self._coefficients()
+        else:
+            return itertools.islice(self.coefficients(), N) 
 
 
     def coefficients_as_list(self, N : int = 40) -> List[int]:
         """The coefficients as a list
 
         """
-        return list(itertools.islice(self.coefficients(), N))
+        return list(self.coefficients(N))
 
 
     def convergents(self) -> Generator[fractions.Fraction, None, None]:


### PR DESCRIPTION
You have coefficients_to_list() which will return a limited number of coefficients as a list. I had a similar situation where I just wanted a limited number but not as a list, as an iterator, so I moved the islice call optionally within coefficients().